### PR TITLE
Use external six package to support Django 3.0

### DIFF
--- a/oracle_json_field/encoders.py
+++ b/oracle_json_field/encoders.py
@@ -1,10 +1,11 @@
 from django.db.models.query import QuerySet
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 import datetime
 import decimal
 import json
+import six
 import uuid
 
 


### PR DESCRIPTION
Django 3.0 has removed django.utils.six module as stated here:
https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis